### PR TITLE
[12.0] [REF] Partner Bank Active: compatibility with old Odoo 12

### DIFF
--- a/partner_bank_active/views/res_partner_bank.xml
+++ b/partner_bank_active/views/res_partner_bank.xml
@@ -10,7 +10,7 @@
         <field name="model">res.partner.bank</field>
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[group[field[@name='sequence']]]" position="before">
+            <xpath expr="//group[group[field[@name='acc_number']]]" position="before">
                 <div class="oe_button_box" name="button_box">
                     <button name="toggle_active"
                             type="object"


### PR DESCRIPTION
The module `partner_bank_active` needs [this](https://github.com/acsone/odoo/commit/1122b62d004dacffb0f71be4276866c3c0685c22) commit to work. This PR patches the view inheritance to work without it.